### PR TITLE
fix(#34): remove orphaned TestValidate to restore green CI

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -397,46 +397,6 @@ class TestPutRequests:
 
 
 # ---------------------------------------------------------------------------
-# async_validate
-# ---------------------------------------------------------------------------
-
-
-class TestValidate:
-    """Tests for async_validate."""
-
-    @pytest.mark.asyncio
-    async def test_validate_success(self):
-        """Successful status fetch returns True."""
-        client = ArcticSpaClient("test_key", session=_make_session(_make_response()))
-        assert await client.async_validate() is True
-
-    @pytest.mark.asyncio
-    async def test_validate_auth_failure_returns_false(self):
-        """ArcticSpaAuthError during validate returns False."""
-        client = ArcticSpaClient("bad_key", session=_make_session(_make_response(status=401)))
-        assert await client.async_validate() is False
-
-    @pytest.mark.asyncio
-    async def test_validate_connection_failure_returns_false(self):
-        """ArcticSpaConnectionError during validate returns False."""
-        session = MagicMock(spec=aiohttp.ClientSession)
-        session.closed = False
-        cm = AsyncMock()
-        cm.__aenter__ = AsyncMock(side_effect=aiohttp.ClientError("unreachable"))
-        cm.__aexit__ = AsyncMock(return_value=False)
-        session.get = MagicMock(return_value=cm)
-
-        client = ArcticSpaClient("test_key", session=session)
-        assert await client.async_validate() is False
-
-    @pytest.mark.asyncio
-    async def test_validate_server_error_returns_false(self):
-        """HTTP 500 during validate returns False."""
-        client = ArcticSpaClient("test_key", session=_make_session(_make_response(status=500)))
-        assert await client.async_validate() is False
-
-
-# ---------------------------------------------------------------------------
 # Session lifecycle
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #34

## Problem
`master` CI has been red since 2026-02-25. The `Test` job fails with:
```
AttributeError: 'ArcticSpaClient' object has no attribute 'async_validate'
```

## Root cause
`56ab979` ("refactor: clean up dead code…") removed `async_validate` from `api.py`, but `tests/test_api.py::TestValidate` (4 tests) still called it. `config_flow.py` validates via `async_get_status()`, so the class was orphaned dead code.

## Fix
Remove the `TestValidate` class. Matches the intent of `56ab979`.

## Verification
```
uv run pytest tests/ -q   → 34 passed
uv run ruff check         → All checks passed
uv run ruff format --check → 12 files already formatted
```

Unblocks every open dependabot PR (all currently show this same pre-existing failure) and the HACS publish (#18).