### PR TITLE
chore(#39): repo hygiene — release-drafter Dependencies, prek hooks, badge, version

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,6 +12,10 @@ categories:
   - title: 'Documentation'
     labels:
       - 'documentation'
+  - title: 'Dependencies'
+    collapse-after: 3
+    labels:
+      - 'dependencies'
 
 change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&'
@@ -28,6 +32,7 @@ version-resolver:
     labels:
       - 'bug'
       - 'documentation'
+      - 'dependencies'
   default: patch
 
 template: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,26 @@
+# JetBrains IDE config is tracked but not something we lint/format.
+exclude: '^\.idea/'
+
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.20
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.11.25
+    hooks:
+      - id: uv-lock

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arctic Spa – Home Assistant Integration
 
-[![HACS Custom](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
+[![HACS Default](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/default)
 [![GitHub Release](https://img.shields.io/github/v/release/jensenbox/ha-arctic-spa)](https://github.com/jensenbox/ha-arctic-spa/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-arctic-spa"
-version = "1.0.0"
+version = "0.1.3"
 description = "Arctic Spa integration for Home Assistant"
 license = {text = "MIT"}
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -233,7 +233,7 @@ wheels = [
 
 [[package]]
 name = "ha-arctic-spa"
-version = "1.0.0"
+version = "0.1.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes #39

Four small hygiene follow-ups in one PR.

### 1. Release Drafter — Dependencies category
`.github/release-drafter.yml`: new **Dependencies** section (label `dependencies`, `collapse-after: 3` so long bump lists fold) and `dependencies` → patch in the version resolver. Dependabot already applies the `dependencies` label, so future bumps group cleanly instead of landing uncategorized.

### 2. README badge
`HACS-Custom` → **`HACS-Default`** badge. Accurate once **hacs/default#8841** merges (submitted, all 12 checks green, in the review queue).

### 3. prek hooks (uv + ruff stack)
Already on **prek** (`j178/prek-action`), so these just slot into `.pre-commit-config.yaml`:
- **`astral-sh/uv-pre-commit` → `uv-lock`** — fails the build if `uv.lock` drifts from `pyproject.toml` (the exact dependabot footgun we just cleaned up).
- **`pre-commit/pre-commit-hooks`** basics — trailing-whitespace, end-of-file-fixer, check-yaml/json/toml, check-merge-conflict, check-added-large-files.
- **ruff** stays the Python linter/formatter (unchanged).
- Top-level `exclude: ^\.idea/` so tracked JetBrains config isn't linted.

### 4. pyproject version
Cosmetic `1.0.0` → `0.1.3` to match the release line; `uv.lock` re-locked to match.

### Verification
```
uvx prek run --all-files   → all hooks pass (incl. uv-lock, EOF, ruff)
uv run pytest tests/ -q    → 34 passed
```

### Noted, out of scope
`.idea/` (JetBrains IDE config) is tracked but not gitignored — excluded from hooks here. Happy to untrack + gitignore it in a follow-up if you want.